### PR TITLE
Fix SnackBar extension name

### DIFF
--- a/lib/core/ui/component/widget_ref_x.dart
+++ b/lib/core/ui/component/widget_ref_x.dart
@@ -8,7 +8,7 @@ extension WidgetRefX on WidgetRef {
   ScaffoldMessengerState? get _currentState =>
       read(scaffoldMessengerKeyProvider).currentState;
 
-  ScaffoldFeatureController<SnackBar, SnackBarClosedReason>? showSnakBar(
+  ScaffoldFeatureController<SnackBar, SnackBarClosedReason>? showSnackBar(
     SnackBar snackBar,
   ) {
     return _currentState?.showSnackBar(snackBar);

--- a/lib/feature/color/ui/component/palette.dart
+++ b/lib/feature/color/ui/component/palette.dart
@@ -133,7 +133,7 @@ class _PaletteState extends ConsumerState<Palette> {
         await Clipboard.setData(ClipboardData(text: hex));
 
         // スナックバーを表示する
-        ref.showSnakBar(
+        ref.showSnackBar(
           SnackBar(
             content: Text('$hex Coppied!'),
             width: snackBarWidth,

--- a/lib/feature/color/ui/component/tonal_palette.dart
+++ b/lib/feature/color/ui/component/tonal_palette.dart
@@ -207,7 +207,7 @@ class _PrimaryCircleColor extends ConsumerWidget {
           await Clipboard.setData(ClipboardData(text: hex));
 
           // スナックバーを表示する
-          ref.showSnakBar(
+          ref.showSnackBar(
             SnackBar(
               content: Text('$hex Coppied!'),
               width: snackBarWidth,

--- a/lib/feature/seed_color_history/ui/component/popup_menu.dart
+++ b/lib/feature/seed_color_history/ui/component/popup_menu.dart
@@ -15,7 +15,7 @@ class SeedColorHistoryPopupMenuButton extends ConsumerWidget {
     ref.listenAsync(
       addSeedColorHistoryUseCaseProvider,
       success: (_) {
-        ref.showSnakBar(
+        ref.showSnackBar(
           const SnackBar(
             content: Text('Saved.'),
             width: snackBarWidth,


### PR DESCRIPTION
## Summary
- rename `showSnakBar` to `showSnackBar`
- adjust call sites

## Testing
- `dart analyze` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842a49b3818832d9e5e454b526bbce8