### PR TITLE
Fix history deletion list handling

### DIFF
--- a/lib/feature/seed_color_history/use_case/delete_seed_color_history.dart
+++ b/lib/feature/seed_color_history/use_case/delete_seed_color_history.dart
@@ -19,12 +19,12 @@ class DeleteSeedColorHistoryUseCase extends _$DeleteSeedColorHistoryUseCase
       invokeInternal(() async {
         final histories =
             ref.read(seedColorHistoryCollectionNotifierProvider).histories;
-        histories.remove(history);
+        final updatedHistories = histories.toList()..remove(history);
 
         await ref.read(seedColorHistoryCollectionBoxProvider).put(
               SeedColorHistoryCollection.keyName,
               SeedColorHistoryCollection(
-                histories: histories,
+                histories: updatedHistories,
               ),
             );
       });


### PR DESCRIPTION
## Summary
- ensure `DeleteSeedColorHistoryUseCase` copies the history list before deleting items

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ad763d3c832da61c655c4659035d